### PR TITLE
fixed two bugs in OM modules

### DIFF
--- a/src/aed2_organic_matter.F90
+++ b/src/aed2_organic_matter.F90
@@ -658,9 +658,9 @@ SUBROUTINE aed2_calculate_organic_matter(data,column,layer_idx)
       oxy = 300.0
    ENDIF
    IF (data%use_nit) THEN
-      oxy = _STATE_VAR_(data%id_nit)! nitrate
+      nit = _STATE_VAR_(data%id_nit)! nitrate
    ELSE
-      oxy = 300.0
+      nit = 300.0
    ENDIF
    IF (data%use_no2) THEN
       no2 = _STATE_VAR_(data%id_no2)! nitrite
@@ -850,7 +850,7 @@ SUBROUTINE aed2_calculate_organic_matter(data,column,layer_idx)
                                     _FLUX_VAR_(data%id_dic) + photolysis*(1.-photo_fmin)
    ENDIF
    IF (data%use_amm) THEN
-      !amm now done above _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) + (don*don_mineralisation)
+      _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) + (don_mineralisation)
       IF ( data%simRPools )  &
          _FLUX_VAR_(data%id_amm) = _FLUX_VAR_(data%id_amm) + &
                                        photolysis*(1.-photo_fmin)*MIN(donr/MAX(docr,1e-2),one_)


### PR DESCRIPTION
I believe there are two bugs on the organic matter module:

1) On lines 661 and 663, oxy is incorrectly set equal to the nitrate variable.  

2) On line 853, it the code said that amm was taken care of above but a search of don_mineralisation did not yield a location in the code were don_minerlisation added to a flux.  don_minerlisation is removed from the don pool on 749 but not subsequently added elsewhere.  I think it should be added to the amm pool.