### PR TITLE
Fixed issue with 2D Fsed variables

### DIFF
--- a/src/aed2_carbon.F90
+++ b/src/aed2_carbon.F90
@@ -1119,13 +1119,19 @@ SUBROUTINE CO2SYS(TEM,Sal,TA0,TC0,fCO2xx,pH00)
 
   REAL                 :: H, Denom, CAlk, BAlk, OH, PhosTop, PhosBot, PAlk, SiAlk, &
                         & FREEtoTOT, Hfree, HSO4, HF, Residual, Slope, deltapH, pHTol, ln10
+ 
+  INTEGER :: count
+  INTEGER :: max_count
 
   pHx      = 8.        !This is the first guess
   pHTol    = 0.0001    !tolerance for iterations end
   ln10     = log(10.)
   deltapH  = pHTol + 1
+  
+  count = 0
+  max_count = 100
 
-  DO WHILE (abs(deltapH) > pHTol)
+  DO WHILE (abs(deltapH) > pHTol .AND. count < max_count)
     H         = 10.**(-pHx)
     Denom     = (H*H + K1F*H + K1F*K2F)
     CAlk      = TCx*K1F*(H + 2.*K2F)/Denom
@@ -1149,7 +1155,7 @@ SUBROUTINE CO2SYS(TEM,Sal,TA0,TC0,fCO2xx,pH00)
     END DO
 
     pHx       = pHx + deltapH  !% Is on the same scale as K1 and K2 were calculated...
-
+    count = count + 1
   END DO
 
   END SUBROUTINE Cal_pHfromTATC

--- a/src/aed2_sedflux.F90
+++ b/src/aed2_sedflux.F90
@@ -405,6 +405,23 @@ SUBROUTINE aed2_define_sedflux(data, namlst)
    ELSE
       PRINT*,"**ERROR : Unknown sedflux model type :", TRIM(sedflux_model)
    ENDIF
+   
+   data%id_Fsed_oxy = 0
+   data%id_Fsed_rsi = 0
+   data%id_Fsed_amm = 0
+   data%id_Fsed_nit = 0
+   data%id_Fsed_frp = 0
+   data%id_Fsed_pon = 0
+   data%id_Fsed_don = 0
+   data%id_Fsed_pop = 0
+   data%id_Fsed_dop = 0
+   data%id_Fsed_poc = 0
+   data%id_Fsed_doc = 0
+   data%id_Fsed_dic = 0
+   data%id_Fsed_ch4 = 0
+   data%id_Fsed_feii = 0
+   data%id_Fsed_n2o = 0
+
 
    ! Register state variables
    ! NOTE the "_sheet_"  which specifies the variable is benthic.


### PR DESCRIPTION
When compiling in gfortran and running with 2D Fsed variables I had a segmentation fault.  I tracked this to the "id" of the 2D variables not being set to 0.  I fixed this and also add a catch to prevent endless iterations in the pH calculation function.   The changes would pull the AED code we are using in FLARE to the main AED code.